### PR TITLE
Bump package.json to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-apps",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",


### PR DESCRIPTION
This PR:
- Updates package.json version to 1.2.1

In 1.2.0 it was not updated and v1.2.0 tag is already used, so had to use 1.2.1