### PR TITLE
WalletConnect: reject for methods different than eth_sendTransaction …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-apps",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",

--- a/src/apps/WalletConnect/hooks/useWalletConnect.tsx
+++ b/src/apps/WalletConnect/hooks/useWalletConnect.tsx
@@ -52,6 +52,7 @@ const useWalletConnect = () => {
         if (error) {
           throw error;
         }
+
         if (payload.method === "eth_sendTransaction") {
           const txInfo = payload.params[0];
           safe.sendTransactions([
@@ -61,6 +62,13 @@ const useWalletConnect = () => {
               data: txInfo.data || "0x",
             },
           ]);
+        } else {
+          wcConnector.rejectRequest({
+            id: payload.id,
+            error: {
+              message: "METHOD_NOT_SUPPORTED",
+            },
+          });
         }
       });
 

--- a/src/apps/WalletConnect/typings/fonts.d.ts
+++ b/src/apps/WalletConnect/typings/fonts.d.ts
@@ -1,2 +1,0 @@
-declare module '*.woff';
-declare module '*.woff2';

--- a/src/apps/WalletConnect/utils.ts
+++ b/src/apps/WalletConnect/utils.ts
@@ -13,7 +13,6 @@ export const blobToImageData = async (blob: string) => {
     if (!ctx) throw new Error("Could not generate context from canvas");
 
     ctx.drawImage(img, 0, 0);
-    console.log({ img });
     return ctx.getImageData(0, 0, img.width, img.height); // some browsers synchronously decode image here
   });
 };


### PR DESCRIPTION
## Safe-react-apps v1.5.2

#### Bugfix
* WalletConnect: Reject methods different than eth_sendTransaction (#49)