### PR TITLE
Add GlobalStyles in Tx-builder and WC

### DIFF
--- a/apps/tx-builder/src/global.ts
+++ b/apps/tx-builder/src/global.ts
@@ -1,0 +1,28 @@
+import { createGlobalStyle } from "styled-components";
+import avertaFont from "@gnosis.pm/safe-react-components/dist/fonts/averta-normal.woff2";
+import avertaBoldFont from "@gnosis.pm/safe-react-components/dist/fonts/averta-bold.woff2";
+
+const GlobalStyle = createGlobalStyle`
+    html {
+        height: 100%
+    }
+
+    body {
+       height: 100%;
+       margin: 0px;
+       padding: 0px;
+    }
+
+    #root {
+        height: 100%;
+    }
+
+    @font-face {
+        font-family: 'Averta';
+        src: local('Averta'), local('Averta Bold'),
+        url(${avertaFont}) format('woff2'),
+        url(${avertaBoldFont}) format('woff');
+    }
+`;
+
+export default GlobalStyle;

--- a/apps/tx-builder/src/index.tsx
+++ b/apps/tx-builder/src/index.tsx
@@ -7,13 +7,17 @@ import * as serviceWorker from "./serviceWorker";
 
 import Dashboard from "./components/Dashboard";
 import SafeProvider from "./providers/SafeProvider";
+import GlobalStyles from "./global";
 
 ReactDOM.render(
-  <ThemeProvider theme={theme}>
-    <SafeProvider>
-      <Dashboard />
-    </SafeProvider>
-  </ThemeProvider>,
+  <>
+    <GlobalStyles />
+    <ThemeProvider theme={theme}>
+      <SafeProvider>
+        <Dashboard />
+      </SafeProvider>
+    </ThemeProvider>
+  </>,
   document.getElementById("root")
 );
 

--- a/apps/tx-builder/src/typings/custom.d.ts
+++ b/apps/tx-builder/src/typings/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+    export default content;
+  }

--- a/apps/tx-builder/src/typings/fonts.d.ts
+++ b/apps/tx-builder/src/typings/fonts.d.ts
@@ -1,0 +1,2 @@
+declare module '*.woff';
+declare module '*.woff2';

--- a/apps/wallet-connect/package.json
+++ b/apps/wallet-connect/package.json
@@ -5,7 +5,7 @@
   "homepage": "./",
   "dependencies": {
     "@gnosis.pm/safe-apps-sdk": "0.4.2",
-    "@gnosis.pm/safe-react-components": "^0.3.0",
+    "@gnosis.pm/safe-react-components": "https://github.com/gnosis/safe-react-components.git#ff29c3c",
     "@rmeissner/safe-apps-react-sdk": "^0.3.4",
     "@walletconnect/client": "^1.1.0",
     "date-fns": "^2.16.1",

--- a/apps/wallet-connect/src/global.ts
+++ b/apps/wallet-connect/src/global.ts
@@ -1,0 +1,28 @@
+import { createGlobalStyle } from "styled-components";
+import avertaFont from "@gnosis.pm/safe-react-components/dist/fonts/averta-normal.woff2";
+import avertaBoldFont from "@gnosis.pm/safe-react-components/dist/fonts/averta-bold.woff2";
+
+const GlobalStyle = createGlobalStyle`
+    html {
+        height: 100%
+    }
+
+    body {
+       height: 100%;
+       margin: 0px;
+       padding: 0px;
+    }
+
+    #root {
+        height: 100%;
+    }
+
+    @font-face {
+        font-family: 'Averta';
+        src: local('Averta'), local('Averta Bold'),
+        url(${avertaFont}) format('woff2'),
+        url(${avertaBoldFont}) format('woff');
+    }
+`;
+
+export default GlobalStyle;

--- a/apps/wallet-connect/src/index.tsx
+++ b/apps/wallet-connect/src/index.tsx
@@ -6,13 +6,17 @@ import { Loader, theme } from "@gnosis.pm/safe-react-components";
 import { ThemeProvider } from "styled-components";
 
 import * as serviceWorker from "./serviceWorker";
+import GlobalStyles from "./global";
 
 ReactDOM.render(
-  <ThemeProvider theme={theme}>
-    <SafeProvider loading={<Loader size="md" />}>
-      <App />
-    </SafeProvider>
-  </ThemeProvider>,
+  <>
+    <GlobalStyles />
+    <ThemeProvider theme={theme}>
+      <SafeProvider loading={<Loader size="md" />}>
+        <App />
+      </SafeProvider>
+    </ThemeProvider>
+  </>,
   document.getElementById("root")
 );
 

--- a/apps/wallet-connect/src/typings/custom.d.ts
+++ b/apps/wallet-connect/src/typings/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+    export default content;
+  }

--- a/apps/wallet-connect/src/typings/fonts.d.ts
+++ b/apps/wallet-connect/src/typings/fonts.d.ts
@@ -1,0 +1,2 @@
+declare module '*.woff';
+declare module '*.woff2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,6 +1414,14 @@
     react-media "^1.10.0"
     url-loader "^4.1.0"
 
+"@gnosis.pm/safe-react-components@https://github.com/gnosis/safe-react-components.git#ff29c3c":
+  version "0.4.0"
+  resolved "https://github.com/gnosis/safe-react-components.git#ff29c3ccfd391142b92edefba0f773aaf16f1799"
+  dependencies:
+    classnames "^2.2.6"
+    polished "^3.6.7"
+    react-media "^1.10.0"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -9321,6 +9329,13 @@ polished@3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.5.tgz#dbefdde64c675935ec55119fe2a2ab627ca82e9c"
   integrity sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+polished@^3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.7.tgz#44cbd0047f3187d83db0c479ef0c7d5583af5fb6"
+  integrity sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==
   dependencies:
     "@babel/runtime" "^7.9.2"
 


### PR DESCRIPTION
Closes #76.

When safe-apps were separated on independent projects, we forgot to add GlobalStyles in tx-builder and wallet-connect. That's why wallet-connect is showing the wrong font. 
