### PR TITLE
[WalletConnect] Compare lowercase addresses for eth_sign

### DIFF
--- a/apps/wallet-connect/src/hooks/useWalletConnect.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnect.tsx
@@ -5,6 +5,7 @@ import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk';
 import { chainIdByNetwork } from '../utils/networks';
 import { encodeSignMessageCall } from '../utils/signatures';
 import { isMetaTxArray } from '../utils/transactions';
+import { areStringsEqual } from '../utils/strings';
 
 export const LOCAL_STORAGE_URI_KEY = 'safeAppWcUri';
 
@@ -92,7 +93,7 @@ const useWalletConnect = () => {
             case 'eth_sign': {
               const [address, messageHash] = payload.params;
 
-              if (address !== safe.safeAddress || !messageHash.startsWith('0x')) {
+              if (!areStringsEqual(address, safe.safeAddress) || !messageHash.startsWith('0x')) {
                 throw new Error('The address or message hash is invalid');
               }
 

--- a/apps/wallet-connect/src/utils/strings.ts
+++ b/apps/wallet-connect/src/utils/strings.ts
@@ -1,0 +1,2 @@
+export const areStringsEqual = (string1: string, string2: string): boolean =>
+  string1.toLowerCase() === string2.toLowerCase();


### PR DESCRIPTION
This PR:
- Closes https://github.com/gnosis/safe-react-apps/issues/100 by converting addresses to lowercase before comparison 