### PR TITLE
[TX-Builder] Always show to field

### DIFF
--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx-builder",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "homepage": "./",
   "dependencies": {

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -218,8 +218,7 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
 
       {contract && !contract?.methods.length && <Text size="lg">Contract ABI doesn't have any public methods.</Text>}
 
-      {/* show `toInput`  when `to` is not a valid address */}
-      {to.length > 0 && !isValidAddress(to) && (
+      {to.length > 0 && (
         <StyledTextField
           style={{ marginTop: 10 }}
           value={toInput}


### PR DESCRIPTION
We are having some limitations on the way that transaction builder can be used. We decided to not show the to field when address was a valid address for interacting, but many people is loading de ABI using MasterCopy address or similar methods.

Restore to input field, even we show a duplicated value to allow people to still use the transaction builder this way