### PR TITLE
[Tx-Builder] Fix negative input number

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -59,7 +59,7 @@ const paramTypeNumber = new RegExp(/^(u?int)([0-9]*)$/);
 const parseInputValue = (input: any, value: string): string => {
   // If there is a match with this regular expression we get an array value like the following
   // ex: ['uint16', 'uint', '16']. If no match, null is returned
-  const isNumberInput = input.type.match(paramTypeNumber)
+  const isNumberInput = paramTypeNumber.test(input.type)
 
   if (value.charAt(0) === '[') {
     return JSON.parse(value.replace(/"/g, '"'));
@@ -67,11 +67,11 @@ const parseInputValue = (input: any, value: string): string => {
     // From web3 1.2.5 negative string numbers aren't correctly padded with leading 0's.
     // To fix that we pad the numeric values here as the encode function is expecting a string
     // more info here https://github.com/ChainSafe/web3.js/issues/3772
-    const bitWidth = isNumberInput[2]
+    const bitWidth = input.type.match(paramTypeNumber)[2]
     return toBN(value).toString(10, bitWidth);
-  } else {
-    return value;
   }
+  
+  return value;
 }
 
 type Props = {

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -133,15 +133,15 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
         const parsedInputs: string[] = [];
         const inputDescription: string[] = [];
 
-        method.inputs.forEach((input, index) => {
-          const cleanValue = inputCache[index] || '';
-          parsedInputs[index] = parseInputValue(input, cleanValue);
-          inputDescription[index] = `${(input.name || input.type)}: ${cleanValue}`;
-        })
-
-        description = `${method.name} (${inputDescription.join(', ')})`;
-
         try {
+          method.inputs.forEach((input, index) => {
+            const cleanValue = inputCache[index] || '';
+            parsedInputs[index] = parseInputValue(input, cleanValue);
+            inputDescription[index] = `${(input.name || input.type)}: ${cleanValue}`;
+          })
+
+          description = `${method.name} (${inputDescription.join(', ')})`;
+
           data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs);
         } catch (error) {
           setAddTxError(error.message);

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -136,10 +136,10 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
         method.inputs.forEach((input, index) => {
           const cleanValue = inputCache[index] || '';
           parsedInputs[index] = parseInputValue(input, cleanValue);
-          inputDescription[index] = (input.name || input.type) + ': ' + cleanValue;
+          inputDescription[index] = `${(input.name || input.type)}: ${cleanValue}`;
         })
 
-        description = method.name + ' (' + inputDescription.join(', ') + ')';
+        description = `${method.name} (${inputDescription.join(', ')})`;
 
         try {
           data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs);

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -11,7 +11,7 @@ import {
 } from '@gnosis.pm/safe-react-components';
 import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk';
 import styled from 'styled-components';
-import { AbiItem } from 'web3-utils';
+import { AbiItem, toBN } from 'web3-utils';
 
 import { ContractInterface } from '../hooks/useServices/interfaceRepository';
 import useServices from '../hooks/useServices';
@@ -42,11 +42,6 @@ const StyledExamples = styled.div`
   }
 `;
 
-type Props = {
-  contract: ContractInterface | null;
-  to: string;
-};
-
 const getInputHelper = (input: any) => {
   // This code renders a helper for the input text.
   if (input.type.startsWith('tuple')) {
@@ -55,6 +50,33 @@ const getInputHelper = (input: any) => {
   } else {
     return input.type;
   }
+};
+
+// Same regex used for web3@1.3.6
+const paramTypeNumber = new RegExp(/^(u?int)([0-9]*)$/);
+
+// This function is used to apply some parsing to some value types
+const parseInputValue = (input: any, value: string): string => {
+  // If there is a match with this regular expression we get an array value like the following
+  // ex: ['uint16', 'uint', '16']. If no match, null is returned
+  const isNumberInput = input.type.match(paramTypeNumber)
+
+  if (value.charAt(0) === '[') {
+    return JSON.parse(value.replace(/"/g, '"'));
+  } else if (isNumberInput) {
+    // From web3 1.2.5 negative string numbers aren't correctly padded with leading 0's.
+    // To fix that we pad the numeric values here as the encode function is expecting a string
+    // more info here https://github.com/ChainSafe/web3.js/issues/3772
+    const bitWidth = isNumberInput[2]
+    return toBN(value).toString(10, bitWidth);
+  } else {
+    return value;
+  }
+}
+
+type Props = {
+  contract: ContractInterface | null;
+  to: string;
 };
 
 export const Builder = ({ contract, to }: Props): ReactElement | null => {
@@ -108,21 +130,19 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
       const method = contract.methods[selectedMethodIndex];
 
       if (!['receive', 'fallback'].includes(method.name)) {
-        const cleanInputs = [];
-        description = method.name + ' (';
-        for (let i = 0; i < method.inputs.length; i++) {
-          const cleanValue = inputCache[i] || '';
-          cleanInputs[i] = cleanValue.charAt(0) === '[' ? JSON.parse(cleanValue.replace(/"/g, '"')) : cleanValue;
-          if (i > 0) {
-            description += ', ';
-          }
-          const input = method.inputs[i];
-          description += (input.name || input.type) + ': ' + cleanValue;
-        }
-        description += ')';
+        const parsedInputs: string[] = [];
+        const inputDescription: string[] = [];
+
+        method.inputs.forEach((input, index) => {
+          const cleanValue = inputCache[index] || '';
+          parsedInputs[index] = parseInputValue(input, cleanValue);
+          inputDescription[index] = (input.name || input.type) + ': ' + cleanValue;
+        })
+
+        description = method.name + ' (' + inputDescription.join(', ') + ')';
 
         try {
-          data = web3.eth.abi.encodeFunctionCall(method as AbiItem, cleanInputs);
+          data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs);
         } catch (error) {
           setAddTxError(error.message);
           return;


### PR DESCRIPTION
Fixes #139 parsing correctly negative number on inputs

From web3 > 1.2.5 there is a bug that parse negative numbers incorrectly adding leading 0's before the minus sign when the value is passed as a string.

The encodeFunctionCall expects that the input values are still passed as string, so to avoid this bug without rolling back to a really old version of web3 we can add the leading 0's for numeric values and that way still send the value as a string