### PR TITLE
[WC] Upgrade the client to the latest version

### DIFF
--- a/apps/wallet-connect/package.json
+++ b/apps/wallet-connect/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.0.13",
     "@gnosis.pm/safe-react-components": "^0.5.0",
-    "@walletconnect/client": "^1.3.6",
+    "@walletconnect/client": "^1.5.2",
     "date-fns": "^2.17.0",
     "jsqr": "^1.3.1"
   },


### PR DESCRIPTION
WalletConnect is asking dapps to update their integration: https://twitter.com/WalletConnect/status/1422169112751529989

<img width="557" alt="Screenshot 2021-08-04 at 10 46 21" src="https://user-images.githubusercontent.com/381895/128151235-53d6f3db-e822-4083-afcf-2c139c6075c1.png">

It looks like they are working on v2 (there's a beta published on NPM). Maybe that would be even better but for now, let's just upgrade to the latest package.