### PR TITLE
[TX Builder] Transactions are initialised when entering a contract with a wrong address (Abi not retrieved properly) 

### DIFF
--- a/apps/tx-builder/src/components/Dashboard.tsx
+++ b/apps/tx-builder/src/components/Dashboard.tsx
@@ -92,7 +92,7 @@ const Dashboard = () => {
     }
 
     try {
-      await sdk.txs.send({ txs: transactions.map((d) => d.raw) }).catch(console.error);
+      await sdk.txs.send({ txs: transactions.map((transaction) => transaction.raw) }).catch(console.error);
       setTransactions([]);
     } catch (e) {
       console.error('Error sending transactions:', e);

--- a/apps/tx-builder/src/components/Dashboard.tsx
+++ b/apps/tx-builder/src/components/Dashboard.tsx
@@ -91,8 +91,12 @@ const Dashboard = () => {
       return;
     }
 
-    await sdk.txs.send({ txs: transactions.map((d) => d.raw) }).catch(console.error);
-    setTransactions([]);
+    try {
+      await sdk.txs.send({ txs: transactions.map((d) => d.raw) }).catch(console.error);
+      setTransactions([]);
+    } catch (e) {
+      console.error('Error sending transactions:', e);
+    }
   }, [sdk.txs, transactions]);
 
   return (

--- a/apps/tx-builder/src/components/Dashboard.tsx
+++ b/apps/tx-builder/src/components/Dashboard.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { ContractInterface } from '../hooks/useServices/interfaceRepository';
 import useServices from '../hooks/useServices';
 import { Builder } from './Builder';
+import { ProposedTransaction } from '../typings/models';
 
 const Wrapper = styled.div`
   display: flex;
@@ -31,9 +32,9 @@ const StyledTextFiled = styled(TextField)`
 `;
 
 const Dashboard = () => {
-  const { safe } = useSafeAppsSDK();
+  const { sdk, safe } = useSafeAppsSDK();
   const services = useServices(safe.chainId);
-
+  const [transactions, setTransactions] = useState<ProposedTransaction[]>([]);
   const [addressOrAbiInput, setAddressOrAbiInput] = useState('');
   const [contract, setContract] = useState<ContractInterface | null>(null);
   const [loadAbiError, setLoadAbiError] = useState(false);
@@ -69,6 +70,31 @@ const Dashboard = () => {
     [services.web3],
   );
 
+  const handleAddTransaction = useCallback(
+    (tx: ProposedTransaction) => {
+      setTransactions([...transactions, tx]);
+    },
+    [transactions],
+  );
+
+  const handleRemoveTransaction = useCallback(
+    (index: number) => {
+      const newTxs = transactions.slice();
+      newTxs.splice(index, 1);
+      setTransactions(newTxs);
+    },
+    [transactions],
+  );
+
+  const handleSubmitTransactions = useCallback(async () => {
+    if (!transactions.length) {
+      return;
+    }
+
+    await sdk.txs.send({ txs: transactions.map((d) => d.raw) }).catch(console.error);
+    setTransactions([]);
+  }, [sdk.txs, transactions]);
+
   return (
     <Wrapper>
       <StyledTitle size="sm">Multisend transaction builder</StyledTitle>
@@ -94,7 +120,17 @@ const Dashboard = () => {
       )}
 
       {/* Builder */}
-      {(isValidAddress(addressOrAbiInput) || contract) && <Builder contract={contract} to={addressOrAbiInput} />}
+      {(isValidAddress(addressOrAbiInput) || contract) && (
+        <Builder
+          contract={contract}
+          to={addressOrAbiInput}
+          chainId={safe.chainId}
+          transactions={transactions}
+          onAddTransaction={handleAddTransaction}
+          onRemoveTransaction={handleRemoveTransaction}
+          onSubmitTransactions={handleSubmitTransactions}
+        />
+      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
## What it solves
Resolves #141 

## How this PR fixes it
The problem was the component Builder being destroyed when the contract address entered is wrong. We moved the transaction management to the parent so they are kept

## How to test it
1) Open the transaction builder inside a Safe web and add a correct contract address for example 0x39aa39c021dfbae8fac545936693ac917d5e7563 (`mainnet`)
2) Add transactions using the `redeemUnderlying` method for example like in the video in #141 
3) Now enter a wrong address (For example deleting some characters) and then a correct one again
4) Transactions should be kept and when trying to submit the data associated should be ok

