### PR TITLE
[TX Builder] encodeFunctionCall not working with boolean values properly

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -57,7 +57,7 @@ const getInputHelper = (input: any) => {
 const paramTypeNumber = new RegExp(/^(u?int)([0-9]*)$/);
 
 // This function is used to apply some parsing to some value types
-const parseInputValue = (input: any, value: string): string | boolean => {
+const parseInputValue = (input: any, value: string): any => {
   // If there is a match with this regular expression we get an array value like the following
   // ex: ['uint16', 'uint', '16']. If no match, null is returned
   const isNumberInput = paramTypeNumber.test(input.type);
@@ -138,7 +138,7 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
       const method = contract.methods[selectedMethodIndex];
 
       if (!['receive', 'fallback'].includes(method.name)) {
-        const parsedInputs: Array<string | boolean> = [];
+        const parsedInputs: any[] = [];
         const inputDescription: string[] = [];
 
         try {
@@ -150,7 +150,7 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
 
           description = `${method.name} (${inputDescription.join(', ')})`;
 
-          data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs as string[]);
+          data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs as any[]);
         } catch (error) {
           setAddTxError((error as Error).message);
           return;

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -68,7 +68,7 @@ const parseInputValue = (input: any, value: string): any => {
   }
 
   if (isBooleanInput) {
-    return value === 'true';
+    return value.toLowerCase() === 'true';
   }
 
   if (isNumberInput) {

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -57,14 +57,21 @@ const getInputHelper = (input: any) => {
 const paramTypeNumber = new RegExp(/^(u?int)([0-9]*)$/);
 
 // This function is used to apply some parsing to some value types
-const parseInputValue = (input: any, value: string): string => {
+const parseInputValue = (input: any, value: string): string | boolean => {
   // If there is a match with this regular expression we get an array value like the following
   // ex: ['uint16', 'uint', '16']. If no match, null is returned
   const isNumberInput = paramTypeNumber.test(input.type);
+  const isBooleanInput = input.type === 'bool';
 
   if (value.charAt(0) === '[') {
     return JSON.parse(value.replace(/"/g, '"'));
-  } else if (isNumberInput) {
+  }
+
+  if (isBooleanInput) {
+    return value === 'true';
+  }
+
+  if (isNumberInput) {
     // From web3 1.2.5 negative string numbers aren't correctly padded with leading 0's.
     // To fix that we pad the numeric values here as the encode function is expecting a string
     // more info here https://github.com/ChainSafe/web3.js/issues/3772
@@ -131,7 +138,7 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
       const method = contract.methods[selectedMethodIndex];
 
       if (!['receive', 'fallback'].includes(method.name)) {
-        const parsedInputs: string[] = [];
+        const parsedInputs: Array<string | boolean> = [];
         const inputDescription: string[] = [];
 
         try {
@@ -143,7 +150,7 @@ export const Builder = ({ contract, to }: Props): ReactElement | null => {
 
           description = `${method.name} (${inputDescription.join(', ')})`;
 
-          data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs);
+          data = web3.eth.abi.encodeFunctionCall(method as AbiItem, parsedInputs as string[]);
         } catch (error) {
           setAddTxError((error as Error).message);
           return;


### PR DESCRIPTION
## What it solves
Resolves #155 

## How this PR fixes it
Calling the `encodeFunctionCall` method with a string (containing a bool) value cause the encoding to always convert to zeroes so the final transaction always show "True". Seems to be a problem with the typing in `web3` as the signature for the method is:

```
encodeFunctionCall(abiItem: AbiItem, params: string[]): string;
```

But if you send a bool value it works just fine. We are forcing the conversion and is fixed

## How to test it
1) Open Tx Builder inside a safe
2) Follow the steps in #155 and add several transactions with true and false values
3) Submit and check in the final bundle that the values were converted right

Test contract for mainnet: `0xef0881ec094552b2e128cf945ef17a6752b4ec5d`

