### PR TITLE
Disconnect WalletConnect session when changing safes

### DIFF
--- a/apps/wallet-connect/src/App.tsx
+++ b/apps/wallet-connect/src/App.tsx
@@ -109,7 +109,7 @@ const App = () => {
       const connectWithUri = (data: string) => {
         if (data.startsWith('wc:')) {
           setIsConnecting(true);
-          wcConnect(data);
+          wcConnect({ uri: data });
         }
       };
 
@@ -121,7 +121,7 @@ const App = () => {
           const code = jsQr(imageData.data, imageData.width, imageData.height);
           if (code?.data) {
             setIsConnecting(true);
-            wcConnect(code.data);
+            wcConnect({ uri: code.data });
           } else {
             setInvalidQRCode(true);
             setInputValue(`Screen Shot ${format(new Date(), 'yyyy-MM-dd')} at ${format(new Date(), 'hh.mm.ss')}`);

--- a/apps/wallet-connect/src/hooks/useWalletConnect.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnect.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import WalletConnect from '@walletconnect/client';
 import { IClientMeta } from '@walletconnect/types';
+import Connector from '@walletconnect/core';
 import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk';
 import { isMetaTxArray } from '../utils/transactions';
 import { areStringsEqual } from '../utils/strings';
@@ -142,6 +143,15 @@ const useWalletConnect = () => {
       if (uri) wcConnect(uri);
     }
   }, [connector, wcConnect]);
+
+  useEffect(() => {
+    if (connector) {
+      const { accounts } = (connector as Connector) || [];
+      if (accounts.length && !accounts.includes(safe.safeAddress)) {
+        wcDisconnect();
+      }
+    }
+  }, [connector, safe.safeAddress, wcDisconnect]);
 
   return { wcClientData, wcConnect, wcDisconnect };
 };

--- a/apps/wallet-connect/src/hooks/useWalletConnect.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnect.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import WalletConnect from '@walletconnect/client';
-import { IClientMeta } from '@walletconnect/types';
+import { IClientMeta, IWalletConnectSession } from '@walletconnect/types';
 import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk';
 import { isMetaTxArray } from '../utils/transactions';
 import { areStringsEqual } from '../utils/strings';
@@ -23,7 +23,7 @@ const useWalletConnect = () => {
   }, [connector]);
 
   const wcConnect = useCallback(
-    async ({ uri, session }) => {
+    async ({ uri, session }: { uri?: string; session?: IWalletConnectSession }) => {
       const wcConnector = new WalletConnect({ uri, session, storageId: localStorageSessionKey.current });
       setConnector(wcConnector);
       setWcClientData(wcConnector.peerMeta);

--- a/apps/wallet-connect/src/hooks/useWalletConnect.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnect.tsx
@@ -1,12 +1,9 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import WalletConnect from '@walletconnect/client';
 import { IClientMeta } from '@walletconnect/types';
-import Connector from '@walletconnect/core';
 import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk';
 import { isMetaTxArray } from '../utils/transactions';
 import { areStringsEqual } from '../utils/strings';
-
-export const LOCAL_STORAGE_URI_KEY = 'safeAppWcUri';
 
 const rejectWithMessage = (connector: WalletConnect, id: number | undefined, message: string) => {
   connector.rejectRequest({ id, error: { message } });
@@ -17,19 +14,19 @@ const useWalletConnect = () => {
   const [wcClientData, setWcClientData] = useState<IClientMeta | null>(null);
   const [connector, setConnector] = useState<WalletConnect | undefined>();
 
+  const localStorageSessionKey = useRef(`session_${safe.safeAddress}`);
+
   const wcDisconnect = useCallback(async () => {
-    connector?.killSession();
-    localStorage.removeItem(LOCAL_STORAGE_URI_KEY);
+    await connector?.killSession();
     setConnector(undefined);
     setWcClientData(null);
   }, [connector]);
 
   const wcConnect = useCallback(
-    async (uri: string) => {
-      const wcConnector = new WalletConnect({ uri });
+    async ({ uri, session }) => {
+      const wcConnector = new WalletConnect({ uri, session, storageId: localStorageSessionKey.current });
       setConnector(wcConnector);
       setWcClientData(wcConnector.peerMeta);
-      localStorage.setItem(LOCAL_STORAGE_URI_KEY, uri);
 
       wcConnector.on('session_request', (error, payload) => {
         if (error) {
@@ -139,19 +136,21 @@ const useWalletConnect = () => {
 
   useEffect(() => {
     if (!connector) {
-      const uri = localStorage.getItem(LOCAL_STORAGE_URI_KEY);
-      if (uri) wcConnect(uri);
+      const session = localStorage.getItem(localStorageSessionKey.current);
+      if (session) {
+        wcConnect({ session: JSON.parse(session) });
+      }
     }
   }, [connector, wcConnect]);
 
-  useEffect(() => {
-    if (connector) {
-      const { accounts } = (connector as Connector) || [];
-      if (accounts.length && !accounts.includes(safe.safeAddress)) {
-        wcDisconnect();
-      }
-    }
-  }, [connector, safe.safeAddress, wcDisconnect]);
+  // useEffect(() => {
+  //   if (connector) {
+  //     const { accounts } = (connector as Connector) || [];
+  //     if (accounts.length && !accounts.includes(safe.safeAddress)) {
+  //       wcDisconnect();
+  //     }
+  //   }
+  // }, [connector, safe.safeAddress, wcDisconnect]);
 
   return { wcClientData, wcConnect, wcDisconnect };
 };

--- a/apps/wallet-connect/src/hooks/useWalletConnect.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnect.tsx
@@ -143,15 +143,6 @@ const useWalletConnect = () => {
     }
   }, [connector, wcConnect]);
 
-  // useEffect(() => {
-  //   if (connector) {
-  //     const { accounts } = (connector as Connector) || [];
-  //     if (accounts.length && !accounts.includes(safe.safeAddress)) {
-  //       wcDisconnect();
-  //     }
-  //   }
-  // }, [connector, safe.safeAddress, wcDisconnect]);
-
   return { wcClientData, wcConnect, wcDisconnect };
 };
 


### PR DESCRIPTION
## What it solves
Resolves #160 

## How this PR fixes it
We now are storing independent sessions for each safe address. When the application starts we look for a session in the localStorage to bring the connection live.

We are using a different way to start the `WalletConnect` instance using `session` or `uri` and sending an optional `storageId` prop for allowing the walletconnect client to store the sessions separate.

## How to test it
1) Open different DApps in different browsers (or mobile apps). The DApps should allow to use WalletConnect. For example you can use:
   - [Uniswap](https://app.uniswap.org/#/swap)
   - [SushiSwap](https://app.sushi.com/es/swap)
   - [Cowswap](https://cowswap.exchange/#/swap)
2) Open different instances of the safe WalletConnect app using different safe addreses
3) Copy the QRs codes and paste them in the safe WalletConnect App. It should create a session with the chosen DApp
4) Change safes and see that the connection is being mantained
5) Disconnect, change safes, reconnect ... and check the sessions are being managed properly
