### PR TITLE
Make the transaction detail in the confirm modal break to next line for avoiding overflow

### DIFF
--- a/apps/tx-builder/src/components/ModalBody.tsx
+++ b/apps/tx-builder/src/components/ModalBody.tsx
@@ -1,9 +1,15 @@
-import { Button, Text } from '@gnosis.pm/safe-react-components';
 import React from 'react';
+import { Button, Text } from '@gnosis.pm/safe-react-components';
 import Box from '@material-ui/core/Box';
+import styled from 'styled-components';
 import { ProposedTransaction } from '../typings/models';
 
 type Props = { txs: Array<ProposedTransaction>; deleteTx: (index: number) => void };
+
+const WrappedText = styled(Text)`
+  word-break: break-all;
+  margin: 5px 0;
+`;
 
 export const ModalBody = ({ txs, deleteTx }: Props) => {
   return (
@@ -20,7 +26,7 @@ export const ModalBody = ({ txs, deleteTx }: Props) => {
           <Button size="md" variant="outlined" iconType="delete" color="error" onClick={() => deleteTx(index)}>
             {''}
           </Button>
-          <Text size="lg">{tx.description}</Text>
+          <WrappedText size="lg">{tx.description}</WrappedText>
         </Box>
       ))}
     </>


### PR DESCRIPTION
## What it solves
Resolves #194 

## How this PR fixes it
Adding a CSS rule for avoiding overflow. We as well added a little margin to separate transactions

## How to test it
1) Open Transaction builder and add some transactions using the contract indicated in the issue
2) Click the send transactions button
3) In the modal, transactions should be visible and not overflowed and the buttons should be clickable
