### PR TITLE
[Drain Safe] Handle exclusions improvements

### DIFF
--- a/apps/drain-safe/package.json
+++ b/apps/drain-safe/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@gnosis.pm/safe-react-components": "^0.8.0",
+    "@gnosis.pm/safe-react-components": "^0.8.6",
     "@material-ui/core": "^4.12.3",
     "bignumber.js": "^9.0.1",
     "web3-eth-abi": "^1.3.6"

--- a/apps/drain-safe/src/GlobalStyle.ts
+++ b/apps/drain-safe/src/GlobalStyle.ts
@@ -23,6 +23,10 @@ const GlobalStyle = createGlobalStyle`
         width: 100% !important;
     }
 
+    tbody > tr {
+        cursor: pointer;
+    }
+
     @font-face {
         font-family: 'Averta';
         src: local('Averta'), local('Averta Bold'),

--- a/apps/drain-safe/src/GlobalStyle.ts
+++ b/apps/drain-safe/src/GlobalStyle.ts
@@ -23,10 +23,6 @@ const GlobalStyle = createGlobalStyle`
         width: 100% !important;
     }
 
-    tbody > tr {
-        cursor: pointer;
-    }
-
     @font-face {
         font-family: 'Averta';
         src: local('Averta'), local('Averta Bold'),

--- a/apps/drain-safe/src/__tests__/App.test.js
+++ b/apps/drain-safe/src/__tests__/App.test.js
@@ -98,7 +98,7 @@ describe('<App />', () => {
   });
 
   it('should allow to order token by numeric prop', async () => {
-    const { container, debug } = renderWithProviders(<App />);
+    const { container } = renderWithProviders(<App />);
 
     await screen.findByText(/chainLink token/i);
     const amountColumnHeaderElement = screen.getByText(/amount/i);

--- a/apps/drain-safe/src/__tests__/App.test.js
+++ b/apps/drain-safe/src/__tests__/App.test.js
@@ -42,7 +42,7 @@ describe('<App />', () => {
     const { container } = renderWithProviders(<App />);
     const { sdk } = useSafeAppsSDK();
 
-    await screen.findByText(/chainLink token/i);
+    await screen.findByText(/chainlink token/i);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '0x301812eb4c89766875eFe61460f7a8bBC0CadB96' } });
     fireEvent.click(screen.getByText(/transfer everything/i));
     await waitFor(() => expect(sdk.txs.send).toHaveBeenCalledWith(mockTxsRequest));
@@ -57,7 +57,7 @@ describe('<App />', () => {
     fireEvent.click(checkboxes[3]);
     fireEvent.click(checkboxes[4]);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '0x301812eb4c89766875eFe61460f7a8bBC0CadB96' } });
-    fireEvent.click(screen.getByText(/transfer everything/i));
+    fireEvent.click(screen.getByText(/transfer 2 assets/i));
 
     await waitFor(() =>
       expect(sdk.txs.send).toHaveBeenCalledWith({
@@ -78,32 +78,44 @@ describe('<App />', () => {
   it('should allow to order token by string prop', async () => {
     const { container } = renderWithProviders(<App />);
 
-    await screen.findByText(/chainLink token/i);
+    await screen.findByText(/chainlink token/i);
     const assetColumnHeaderElement = screen.getByText(/asset/i);
+    fireEvent.click(assetColumnHeaderElement);
+
+    await waitFor(() => {
+      const tableRows = document.querySelectorAll('tbody tr');
+      expect(within(tableRows[0]).getByText(/chainlink token/i)).toBeDefined();
+      expect(within(tableRows[4]).getByText(/uniswap/i)).toBeDefined();
+    });
 
     fireEvent.click(assetColumnHeaderElement);
-    const tableRows = document.querySelectorAll('tbody tr');
-    expect(within(tableRows[0]).getByText(/chainLink token/i)).toBeDefined();
-    expect(within(tableRows[4]).getByText(/uniswap/i)).toBeDefined();
 
-    fireEvent.click(assetColumnHeaderElement);
-    expect(within(tableRows[4]).getByText(/chainLink token/i)).toBeDefined();
-    expect(within(tableRows[0]).getByText(/uniswap/i)).toBeDefined();
+    await waitFor(() => {
+      const tableRows = document.querySelectorAll('tbody tr');
+      expect(within(tableRows[4]).getByText(/chainlink token/i)).toBeDefined();
+      expect(within(tableRows[0]).getByText(/uniswap/i)).toBeDefined();
+    });
   });
 
   it('should allow to order token by numeric prop', async () => {
-    const { container } = renderWithProviders(<App />);
+    const { container, debug } = renderWithProviders(<App />);
 
     await screen.findByText(/chainLink token/i);
     const amountColumnHeaderElement = screen.getByText(/amount/i);
+    fireEvent.click(amountColumnHeaderElement);
+
+    await waitFor(() => {
+      const tableRows = document.querySelectorAll('tbody tr');
+      expect(within(tableRows[0]).getByText(/dai/i)).toBeDefined();
+      expect(within(tableRows[4]).getByText(/maker/i)).toBeDefined();
+    });
 
     fireEvent.click(amountColumnHeaderElement);
-    const tableRows = document.querySelectorAll('tbody tr');
-    expect(within(tableRows[0]).getByText(/dai/i)).toBeDefined();
-    expect(within(tableRows[4]).getByText(/maker/i)).toBeDefined();
 
-    fireEvent.click(amountColumnHeaderElement);
-    expect(within(tableRows[4]).getByText(/dai/i)).toBeDefined();
-    expect(within(tableRows[0]).getByText(/maker/i)).toBeDefined();
+    await waitFor(() => {
+      const tableRows = document.querySelectorAll('tbody tr');
+      expect(within(tableRows[4]).getByText(/dai/i)).toBeDefined();
+      expect(within(tableRows[0]).getByText(/maker/i)).toBeDefined();
+    });
   });
 });

--- a/apps/drain-safe/src/components/Balances.tsx
+++ b/apps/drain-safe/src/components/Balances.tsx
@@ -105,7 +105,6 @@ function Balances({
       sortedByHeaderId={orderBy}
       sortDirection={order}
       onHeaderClick={handleHeaderClick}
-      onRowClick={handleExclusion}
     />
   );
 }

--- a/apps/drain-safe/src/components/Balances.tsx
+++ b/apps/drain-safe/src/components/Balances.tsx
@@ -21,7 +21,7 @@ const HEADERS = [
   { id: 'tokenInfo.name', label: 'Asset' },
   { id: 'balance', label: 'Amount' },
   { id: 'fiatBalance', label: `Value, ${CURRENCY}` },
-  { id: 'exclude', label: 'Exclude', hideSortIcon: true },
+  { id: 'transfer', label: 'Transfer', hideSortIcon: true },
 ];
 
 function Balances({
@@ -38,7 +38,7 @@ function Balances({
 
   const handleHeaderClick = useCallback(
     (headerId: string) => {
-      if (headerId === 'exclude') {
+      if (headerId === 'transfer') {
         return;
       }
 
@@ -52,10 +52,11 @@ function Balances({
   );
 
   const handleExclusion = useCallback(
-    (address: string, checked: boolean) => {
-      onExcludeChange(address, checked);
+    (rowId: string) => {
+      const isRowChecked = exclude.includes(rowId);
+      onExcludeChange(rowId, isRowChecked);
     },
-    [onExcludeChange],
+    [onExcludeChange, exclude],
   );
 
   const rows = useMemo(
@@ -63,11 +64,11 @@ function Balances({
       assets
         .slice()
         .sort(getComparator(order, orderBy))
-        .map((item: TokenBalance, index: number) => {
+        .map((item: TokenBalance) => {
           const token = item.tokenInfo || ethToken;
 
           return {
-            id: `row${index}`,
+            id: item.tokenInfo.address,
             cells: [
               {
                 content: (
@@ -85,9 +86,9 @@ function Balances({
                 content: (
                   <Checkbox
                     label=""
-                    name="exclude"
-                    checked={exclude.includes(item.tokenInfo.address)}
-                    onChange={(_, checked) => handleExclusion(item.tokenInfo.address, checked)}
+                    name="transfer"
+                    checked={!exclude.includes(item.tokenInfo.address)}
+                    onChange={() => handleExclusion(item.tokenInfo.address)}
                   />
                 ),
               },
@@ -104,6 +105,7 @@ function Balances({
       sortedByHeaderId={orderBy}
       sortDirection={order}
       onHeaderClick={handleHeaderClick}
+      onRowClick={handleExclusion}
     />
   );
 }

--- a/apps/drain-safe/src/components/CancelButton.tsx
+++ b/apps/drain-safe/src/components/CancelButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Loader } from '@gnosis.pm/safe-react-components';
 import Flex from './Flex';
 
-function CancelButton(): JSX.Element {
+function CancelButton({ children }: { children: string }): JSX.Element {
   return (
     <>
       <Flex centered>
@@ -9,7 +9,7 @@ function CancelButton(): JSX.Element {
       </Flex>
       <Flex centered>
         <Button size="lg" color="secondary" type="reset">
-          Cancel
+          {children}
         </Button>
       </Flex>
     </>

--- a/apps/drain-safe/src/components/SubmitButton.tsx
+++ b/apps/drain-safe/src/components/SubmitButton.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@gnosis.pm/safe-react-components';
 import Flex from './Flex';
 
-function SubmitButton(): JSX.Element {
+function SubmitButton({ children, disabled }: { children: string; disabled?: boolean }): JSX.Element {
   return (
     <Flex centered>
-      <Button size="lg" color="primary" variant="contained" type="submit">
-        Transfer everything
+      <Button size="lg" color="primary" variant="contained" type="submit" disabled={disabled}>
+        {children}
       </Button>
     </Flex>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,10 +1987,10 @@
     classnames "^2.2.6"
     react-media "^1.10.0"
 
-"@gnosis.pm/safe-react-components@^0.8.0":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-0.8.5.tgz#bc8ed6bd74db68c49da7ba706d77f9ba5fa4b092"
-  integrity sha512-gvqbuUGhDtjCTF8u+s6jEC0PkWXNMHQQum6rHQktgfnZ/X1WgxnIifooQvXT6MEpOCgkRxEYE+bowxp+eih6FA==
+"@gnosis.pm/safe-react-components@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-0.8.6.tgz#a8275b02d41a7b0d69abef867900843a1a49bb11"
+  integrity sha512-lWHSjOQFmeck6D4cpzs6un09Zx7jptmdR3+QtUkB0obsmguU0o6fXtkK91SYE2Fm86GpmjhA03rKrOqzEeklBA==
   dependencies:
     react-media "^1.10.0"
 


### PR DESCRIPTION
## What it solves
Resolves #201 

## How this PR fixes it
We are changing the UX for excluding tokens. Instead selecting what to exclude now we are going to see a transfer column with all the assets selected by default. Then we can exclude assets by unselecting the corresponding checkbox in the asset row.

The transfer button is enhance as well showing the current status of the selection (Everything or N assets) and is able to detect no assets selected and change to a disable status.

## How to test it
Open a safe-web with the corresponding custom app pointing to the pr deployed url

