### PR TITLE
[TX BUILDER] Add input validation before adding transactions

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -125,7 +125,7 @@ export const Builder = ({
 
   const isInputValueValid = useCallback((val: string) => {
     const value = Number(val);
-    if (isNaN(value) || value <= 0) {
+    if (isNaN(value) || value < 0) {
       return false;
     }
 

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -123,6 +123,15 @@ export const Builder = ({
     setInputCache(inputCache.slice());
   };
 
+  const isInputValueValid = useCallback((val: string) => {
+    const value = Number(val);
+    if (isNaN(value) || value <= 0) {
+      return false;
+    }
+
+    return true;
+  }, []);
+
   const getContractMethod = useCallback(() => contract?.methods[selectedMethodIndex], [contract, selectedMethodIndex]);
 
   const handleSubmit = () => {
@@ -140,6 +149,11 @@ export const Builder = ({
     const web3 = services.web3;
 
     if (!web3) {
+      return;
+    }
+
+    if (!isInputValueValid(valueInput)) {
+      setValueError(`${nativeCurrencySymbol} value`);
       return;
     }
 
@@ -206,8 +220,7 @@ export const Builder = ({
 
   const onValueInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValueError(undefined);
-    const value = Number(e.target.value);
-    if (isNaN(value) || value < 0) {
+    if (!isInputValueValid(e.target.value)) {
       setValueError(`${nativeCurrencySymbol} value`);
     }
     setValueInput(e.target.value);

--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -81,6 +81,15 @@ const parseInputValue = (input: any, value: string): any => {
   return value;
 };
 
+const isInputValueValid = (val: string) => {
+  const value = Number(val);
+  if (isNaN(value) || value < 0) {
+    return false;
+  }
+
+  return true;
+};
+
 type Props = {
   contract: ContractInterface | null;
   to: string;
@@ -122,15 +131,6 @@ export const Builder = ({
     inputCache[inputIndex] = input;
     setInputCache(inputCache.slice());
   };
-
-  const isInputValueValid = useCallback((val: string) => {
-    const value = Number(val);
-    if (isNaN(value) || value < 0) {
-      return false;
-    }
-
-    return true;
-  }, []);
 
   const getContractMethod = useCallback(() => contract?.methods[selectedMethodIndex], [contract, selectedMethodIndex]);
 


### PR DESCRIPTION
## What it solves
Resolves #195 

## How this PR fixes it
Adding validation for the input value before adding the transaction

## How to test it
1) Add a contract with no abi
2) Enter incorrect values like characters, negatives ... and check you cannot add a transaction after pressing the "Add transaction" button
3) Add correct values and check you can add transactions

