### PR TITLE
Initial value using inputProps for destination address

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactElement, useCallback, useMemo, ChangeEvent } from 'react';
+import React, { useState, useEffect, ReactElement, useCallback, ChangeEvent } from 'react';
 import {
   Button,
   Text,
@@ -103,7 +103,6 @@ type Props = {
 export const Builder = ({
   contract,
   to,
-  chainId,
   nativeCurrencySymbol,
   transactions,
   onAddTransaction,
@@ -372,17 +371,6 @@ export const Builder = ({
     );
   };
 
-  const showAddressInput = useMemo(() => {
-    let isAddress;
-
-    try {
-      isAddress = services?.web3?.utils.isAddress(to);
-    } catch {
-      isAddress = false;
-    }
-    return (isAddress && toInput) || !isAddress;
-  }, [services?.web3?.utils, to, toInput]);
-
   if (!contract && !isValueInputVisible) {
     return null;
   }
@@ -392,20 +380,19 @@ export const Builder = ({
       <Title size="xs">Transaction information</Title>
       {contract && !contract?.methods.length && <Text size="lg">Contract ABI doesn't have any public methods.</Text>}
 
-      {showAddressInput && (
-        <StyledAddressInput
-          id={'to-address-input'}
-          name="toAddress"
-          label="To Address"
-          address={toInput}
-          showNetworkPrefix={!!networkPrefix}
-          networkPrefix={networkPrefix}
-          error={toInput && !isValidAddress(toInput) ? 'Invalid Address' : ''}
-          getAddressFromDomain={getAddressFromDomain}
-          onChangeAddress={onChangeToAddress}
-          hiddenLabel={false}
-        />
-      )}
+      <StyledAddressInput
+        id={'to-address-input'}
+        name="toAddress"
+        label="To Address"
+        address={toInput}
+        showNetworkPrefix={!!networkPrefix}
+        networkPrefix={networkPrefix}
+        error={toInput && !isValidAddress(toInput) ? 'Invalid Address' : ''}
+        getAddressFromDomain={getAddressFromDomain}
+        onChangeAddress={onChangeToAddress}
+        hiddenLabel={false}
+        inputProps={{ value: toInput }}
+      />
 
       {/* ValueInput */}
       {isValueInputVisible && (


### PR DESCRIPTION
## What it solves
Resolves #226 

## How this PR fixes it
The concrete error specified in this issue was not happening anymore but other one arise. When removed the address value the field itself is removed so this PR fixed this other error instead:

https://user-images.githubusercontent.com/1576776/146756577-bfea4903-a753-4b95-932b-0c51afc15b75.mov

## How to test it
1) For the concrete error in this issue => Add an invalid transaction and see the error being showed (There was an error trying to add the transaction). Then add a valid address and click the Add transaction button to see that the error message is not showed anymore
2) Repeat the process but delete the value in the address field as showed in the video. The address field should be kept in the UI


