### PR TITLE
[TX BUILDER] Align Field Styles

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -53,7 +53,7 @@ const StyledTextField = styled(TextFieldInput)`
 const StyledAddressInput = styled(AddressInput)`
   && {
     width: 520px;
-    margin-bottom: 10px;
+    margin-bottom: 1px;
 
     .MuiFormLabel-root {
       color: #0000008a;
@@ -75,7 +75,7 @@ const StyledSelect = styled(Select)`
 `;
 
 const StyledExamples = styled.div`
-  margin-bottom: 10px;
+  margin: 5px 0 10px 0;
 
   button {
     padding: 0;
@@ -281,7 +281,7 @@ export const Builder = ({
   const onValueInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValueError(undefined);
     if (!isInputValueValid(e.target.value)) {
-      setValueError(`${nativeCurrencySymbol} value`);
+      setValueError(`Invalid ${nativeCurrencySymbol} value`);
     }
     setValueInput(e.target.value);
   };

--- a/apps/tx-builder/src/components/Dashboard.tsx
+++ b/apps/tx-builder/src/components/Dashboard.tsx
@@ -38,7 +38,6 @@ const CheckIconAddressAdornment = styled(CheckCircle)`
 const StyledAddressInput = styled(AddressInput)`
   && {
     width: 520px;
-    margin-bottom: 10px;
 
     .MuiFormLabel-root {
       color: #0000008a;


### PR DESCRIPTION
## What it solves
Resolves #228

## How this PR fixes it
Most of the styles were fixed in other PRS
In this one we are adding "Invalid" in front of the "ETH value" label when the field has an error. This should be enough for aligning all the styles

## How to test it
1) Open TX Builder
2) Add a contract with no ABI for seeing the ETH value field. Enter a -1 and see how the label change to "Invalid ETH value"
