### PR TITLE
[TX Builder] Added valueError check to avoid adding tx with negative asset values

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -208,7 +208,7 @@ export const Builder = ({
     let description = '';
     let data = '';
 
-    if (!services?.web3) {
+    if (!services?.web3 || valueError) {
       return;
     }
 


### PR DESCRIPTION
## What it solves
Resolves #263 

## How this PR fixes it

Added valueError check in the addTransaction function to avoid adding transactions with negative asset values.

```
  const addTransaction = async () => {
    let description = '';
    let data = '';

    if (!services?.web3 || valueError) {
      return;
    }
```
## How to test it

Type a negative value in the asset value field and click on "Add Transaction" Button.
