### PR TITLE
[TX Builder] Initialize field values when changing the contract method

### DIFF
--- a/apps/tx-builder/src/components/Builder.tsx
+++ b/apps/tx-builder/src/components/Builder.tsx
@@ -420,6 +420,7 @@ export const Builder = ({
             onItemClick={(id: string) => {
               setAddTxError(undefined);
               handleMethod(Number(id));
+              setInputCache([]);
             }}
           />
           <StyledExamples>


### PR DESCRIPTION
## What it solves
Resolves #241 

## How this PR fixes it
By resetting form field values on method change

## How to test it
1) Open Tx Builder with a contract with ABI and several methods
2) Select one method and fill values
3) Change to other method. Values should be cleaned up
