### PR TITLE
[Drain Safe] Fix button message

### DIFF
--- a/apps/drain-safe/src/hooks/use-balances.ts
+++ b/apps/drain-safe/src/hooks/use-balances.ts
@@ -26,8 +26,10 @@ function useBalances(safeAddress: string, chainId: number): BalancesType {
 
     try {
       const balances = await sdk.safe.experimental_getBalances({ currency: 'USD' });
-      setAssets(balances.items.filter(transferableTokens));
-      setSelectedTokens(balances.items.map((token: any) => token.tokenInfo.address));
+      const assets = balances.items.filter(transferableTokens);
+
+      setAssets(assets);
+      setSelectedTokens(assets.map((token: TokenBalance) => token.tokenInfo.address));
     } catch (err) {
       setError(err as Error);
     }


### PR DESCRIPTION
## What it solves
Resolves #284 

## How this PR fixes it
By calculating from the same filtered assets both the selected and the ones showed in the table

## How to test it
1) Open Drain Safe with an account with a native token with value 0 among other assets
2) Check the display message in the button is showing the correct number of assets

