### PR TITLE
ci: fix bash script and hardcode ref for release job

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -105,6 +105,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: main
 
       - uses: ./.github/actions/setup-env
 

--- a/scripts/deploy_to_s3_bucket.sh
+++ b/scripts/deploy_to_s3_bucket.sh
@@ -9,9 +9,9 @@ function deploy_app {
   | awk -F: '{ print $2 }' \
   | sed 's/[",]//g')
   
-  if [ -n "$APPEND_TAG"]
+  if [ -n "$APPEND_TAG" ]
   then
-    aws s3 sync $BUNDLE_FOLDER s3://${BUCKET_NAME}/$1/$PACKAGE_VERSION --delete
+    aws s3 sync $BUNDLE_FOLDER s3://${BUCKET_NAME}/$1/"$PACKAGE_VERSION" --delete
   else
     aws s3 sync $BUNDLE_FOLDER s3://${BUCKET_NAME}/$1 --delete
   fi


### PR DESCRIPTION
## What it solves
After merging #308, the action failed. This PR wants to fix that

## How this PR fixes it
There was a missing space in the if statement that checks for a set ENV variable.

Also, in the AWS script it wraps the package version in double-quotes because https://stackoverflow.com/questions/51757107/unknown-options-when-using-aws-s3-mv

## How to test it
in production
