### PR TITLE
feat: Check if PR titles are conventional commit formatted

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,17 @@
+<!--
+Remember to create a title following the Conventional Commits guidelines. Examples for valid PR titles are:
+
+fix: Some thing found in the repo
+feat: Add some feature
+refactor!: Make some refactor
+feat(wallet-connect): Add some feature
+
+Note that since PR titles only have a single line, you have to use the ! syntax for breaking changes.
+
+For more examples, take a look at:
+- https://www.conventionalcommits.org/en/v1.0.0
+-->
+
 ## What it solves
 Resolves #
 

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -1,0 +1,17 @@
+name: 'Conventional commit check'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding a workflow for check the PR titles are conventional commit formatted and therefore we avoid rebasing commit messages before creating releases if we make some mistake

https://github.com/marketplace/actions/semantic-pull-request

After checking this is working fine we can remove the husky for checking the messages as when we are working on PRs is not useful