### PR TITLE
fix(tx-builder): parse testBoolArray values in a different way as the encode method don't understand strings

### DIFF
--- a/apps/tx-builder/src/utils.ts
+++ b/apps/tx-builder/src/utils.ts
@@ -52,7 +52,19 @@ export const parseInputValue = (input: any, value: string): any => {
   const isBooleanInput = input.type === 'bool';
 
   if (value.charAt(0) === '[') {
-    return JSON.parse(value.replace(/"/g, '"'));
+    const parsed = JSON.parse(value.replace(/"/g, '"'));
+
+    if (input.type === 'bool[]') {
+      return parsed.map((value: boolean | string) => {
+        if (typeof value == 'string') {
+          return value.toLowerCase() === 'true';
+        }
+
+        return value;
+      });
+    }
+
+    return parsed;
   }
 
   if (isBooleanInput) {


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/316

## How this PR fixes it
When encoding bool[] type, if the array contains strings as "true"or "false" the encode result is always true values. We had same issue for normal bool type. 

For resolving this we are going to parse the array en convert the values to proper booleans

