### PR TITLE
fix(tx-builder): tx-builder design adjustments 

### DIFF
--- a/apps/drain-safe/src/components/AddressInput.tsx
+++ b/apps/drain-safe/src/components/AddressInput.tsx
@@ -4,7 +4,6 @@ import { AddressInput } from '@gnosis.pm/safe-react-components';
 export default styled(AddressInput)`
   && {
     width: 520px;
-    margin-bottom: 10px;
 
     .MuiFormLabel-root {
       color: #0000008a;

--- a/apps/drain-safe/src/components/AddressInput.tsx
+++ b/apps/drain-safe/src/components/AddressInput.tsx
@@ -4,6 +4,7 @@ import { AddressInput } from '@gnosis.pm/safe-react-components';
 export default styled(AddressInput)`
   && {
     width: 520px;
+    margin-bottom: 10px;
 
     .MuiFormLabel-root {
       color: #0000008a;

--- a/apps/tx-builder/src/components/TransactionBatchListItem.tsx
+++ b/apps/tx-builder/src/components/TransactionBatchListItem.tsx
@@ -310,16 +310,26 @@ const StyledAccordion = styled(Accordion).withConfig({
 
   &.MuiAccordion-root {
     margin-bottom: 0;
-    border-color: ${({ isDragging }) => (isDragging ? '#92c9be' : '#e8e7e6')};
+    border-color: ${({ isDragging, expanded }) => (isDragging || expanded ? '#92c9be' : '#e8e7e6')};
     transition: border-color 0.5s linear;
   }
 
   .MuiAccordionSummary-root {
     height: 52px;
     padding: 0px 8px;
+    background-color: ${({ isDragging }) => (isDragging ? '#EFFAF8' : '#FFFFFF')};
+
+    &:hover {
+      background-color: #ffffff;
+    }
 
     .MuiIconButton-root {
       padding: 8px;
+    }
+
+    &.Mui-expanded {
+      background-color: #effaf8;
+      border-color: ${({ isDragging, expanded }) => (isDragging || expanded ? '#92c9be' : '#e8e7e6')};
     }
   }
 

--- a/apps/tx-builder/src/components/forms/fields/AddressContractField.tsx
+++ b/apps/tx-builder/src/components/forms/fields/AddressContractField.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components';
 import { ReactElement } from 'react';
 import { AddressInput } from '@gnosis.pm/safe-react-components';
 
@@ -14,7 +13,7 @@ const AddressContractField = ({
   onBlur,
 }: any): ReactElement => {
   return (
-    <StyledAddressInput
+    <AddressInput
       id={id}
       name={name}
       label={label}
@@ -34,9 +33,3 @@ const AddressContractField = ({
 };
 
 export default AddressContractField;
-
-const StyledAddressInput = styled(AddressInput)`
-  && {
-    margin-bottom: 10px;
-  }
-`;

--- a/apps/tx-builder/src/components/forms/fields/SelectContractField.tsx
+++ b/apps/tx-builder/src/components/forms/fields/SelectContractField.tsx
@@ -1,6 +1,5 @@
 import { Select } from '@gnosis.pm/safe-react-components';
 import { SelectItem } from '@gnosis.pm/safe-react-components/dist/inputs/Select';
-import styled from 'styled-components';
 
 type SelectContractFieldTypes = {
   options: SelectItem[];
@@ -12,7 +11,7 @@ type SelectContractFieldTypes = {
 
 const SelectContractField = ({ value, onChange, options, label, name }: SelectContractFieldTypes) => {
   return (
-    <StyledSelect
+    <Select
       name={name}
       label={label}
       items={options}
@@ -26,7 +25,3 @@ const SelectContractField = ({ value, onChange, options, label, name }: SelectCo
 };
 
 export default SelectContractField;
-
-const StyledSelect = styled(Select)`
-  margin-bottom: 10px;
-`;

--- a/apps/tx-builder/src/components/forms/fields/TextContractField.tsx
+++ b/apps/tx-builder/src/components/forms/fields/TextContractField.tsx
@@ -14,7 +14,6 @@ export default TextContractField;
 
 const StyledTextField = styled(TextFieldInput)`
   && {
-    margin-bottom: 10px;
     textarea {
       &.MuiInputBase-input {
         padding: 0;

--- a/apps/tx-builder/src/global.ts
+++ b/apps/tx-builder/src/global.ts
@@ -38,7 +38,7 @@ const GlobalStyle = createGlobalStyle`
         }
     
         .MuiFormControl-root  {
-            min-height: 80px;
+            min-height: 82px;
             margin-bottom: 0;
         }
 

--- a/apps/tx-builder/src/global.ts
+++ b/apps/tx-builder/src/global.ts
@@ -38,7 +38,12 @@ const GlobalStyle = createGlobalStyle`
         }
     
         .MuiFormControl-root  {
-            min-height: 79px;
+            min-height: 80px;
+            margin-bottom: 0;
+        }
+
+        .MuiTooltip-tooltip {
+            border: 0 !important;
         }
     }
 `;


### PR DESCRIPTION
## What it solves
Resolves #368

## How this PR fixes it

minor fixes in the css (fields, tooltip & transaction item)

## How to test it

1. Hover a button with a tooltip and verify that no border is present.
2. In the transaction form, verify that the distance between fields is ~~24px~~ updated to 26px.
3. In the transaction list, hover and drag & drop background color should follow [the design](https://www.figma.com/file/G7snLqBXWNPANcOj5MhiR7/Transaction-Builder?node-id=832%3A9776) (no grey background)

## Screenshots

![Captura de pantalla 2022-03-14 a las 16 24 18](https://user-images.githubusercontent.com/26763673/158207439-48cf6376-4cc5-45a8-a1bd-1ae4fa208ca0.png)
![Captura de pantalla 2022-03-14 a las 16 24 50](https://user-images.githubusercontent.com/26763673/158207447-b43b596c-acd5-49d2-b9f3-183ee2b0ae0d.png)
![Captura de pantalla 2022-03-14 a las 13 44 05](https://user-images.githubusercontent.com/26763673/158174566-706dda3c-309d-453b-8ff7-cb0617e7a228.png)
<img width="906" alt="Captura de pantalla 2022-03-14 a las 13 45 02" src="https://user-images.githubusercontent.com/26763673/158174748-7632481f-1ea6-470d-955d-96adfd56026c.png">
![Captura de pantalla 2022-03-14 a las 13 45 30](https://user-images.githubusercontent.com/26763673/158174755-238ef706-2383-41c1-8cc8-0ca3d550e54f.png)
