### PR TITLE
fix: missing infura token 

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -15,6 +15,9 @@ inputs:
   prod-deployment-hook-url:
     description: URL of the webhook that triggers the deployment to production
     required: true
+  react-app-rpc-token:
+    description: Infura RPC API token
+    required: true
 
 runs:
   using: composite
@@ -39,6 +42,7 @@ runs:
         PROD_DEPLOYMENT_HOOK_URL: ${{ inputs.prod-deployment-hook-url }}
         BUCKET_NAME: ${{ inputs.bucket-name }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        REACT_APP_RPC_TOKEN: ${{ inputs.react-app-rpc-token }}
 
     - name: Push changes
       uses: ad-m/github-push-action@8407731efefc0d8f72af254c74276b7a90be36e1

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -3,7 +3,7 @@ name: Prepare environment
 description: Prepare environment in the CI runner and install dependencies
 
 inputs:
-  node_version:
+  node-version:
     description: Node.js version
     required: false
     default: '16'
@@ -23,7 +23,7 @@ runs:
     - name: Node.js setup
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ inputs.node_version }}
+        node-version: ${{ inputs.node-version }}
         cache: 'yarn'
         cache-dependency-path: '**/yarn.lock'
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -82,6 +82,9 @@ jobs:
         run: |
           npx nx affected --target=test --parallel
           npx nx affected --target=build --parallel
+        env:
+          REACT_APP_RPC_TOKEN: ${{ secrets.REACT_APP_RPC_TOKEN }}
+
       # Script to deploy to the dev environment
       - name: 'Deploy to S3: Develop'
         if: github.ref == 'refs/heads/development'
@@ -120,3 +123,5 @@ jobs:
           prod-deployment-hook-token: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           prod-deployment-hook-url: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
           bucket-name: ${{ secrets.STAGING_BUCKET_NAME }}/releases
+          react-app-rpc-token: ${{ secrets.REACT_APP_RPC_TOKEN }}
+


### PR DESCRIPTION
## What it solves
Solves an issue where some queries to Infura couldn't be resolved

## How this PR fixes it
Restores the Infura RPC API configuration in the build steps that require it

## How to test it
 - Test that Compound can fetch balances on mainnet
