### PR TITLE
fix(tx-builder): JsonField value when tx service abi returns undefined

### DIFF
--- a/apps/tx-builder/src/pages/Dashboard.tsx
+++ b/apps/tx-builder/src/pages/Dashboard.tsx
@@ -58,7 +58,13 @@ const Dashboard = ({
       try {
         if (isValidAddress(address)) {
           setIsABILoading(true);
-          setAbi(JSON.stringify(await interfaceRepo.loadAbi(address)));
+          const abiResponse = await interfaceRepo.loadAbi(address);
+
+          if (abiResponse) {
+            setAbi(JSON.stringify(abiResponse));
+          } else {
+            setAbi('');
+          }
         }
       } catch (e) {
         setAbi('');


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/359

## How this PR fixes it
By setting an empty string in case the return value from tx-service is null/undefined