### PR TITLE
fix(tx-builder): Content editable firefox bug

### DIFF
--- a/apps/tx-builder/src/components/EditableLabel.tsx
+++ b/apps/tx-builder/src/components/EditableLabel.tsx
@@ -21,7 +21,7 @@ const EditableLabel = ({ children, onEdit }: EditableLabelProps) => {
 
 export default EditableLabel;
 
-const EditableComponent = styled.span`
+const EditableComponent = styled.div`
   display: block;
   white-space: nowrap;
   overflow: hidden;

--- a/apps/tx-builder/src/components/EditableLabel.tsx
+++ b/apps/tx-builder/src/components/EditableLabel.tsx
@@ -22,6 +22,7 @@ const EditableLabel = ({ children, onEdit }: EditableLabelProps) => {
 export default EditableLabel;
 
 const EditableComponent = styled.div`
+  font-family: Averta, 'Roboto', sans-serif;
   display: block;
   white-space: nowrap;
   overflow: hidden;

--- a/apps/tx-builder/src/pages/TransactionLibrary.tsx
+++ b/apps/tx-builder/src/pages/TransactionLibrary.tsx
@@ -54,13 +54,13 @@ const TransactionLibrary = () => {
               </TransactionCounterDot>
 
               {/* editable batch name */}
-              <StyledBatchTitle size="xl">
+              <StyledBatchTitle>
                 <Tooltip placement="top" title="Edit batch name" backgroundColor="primary" textColor="white" arrow>
-                  <span>
+                  <div>
                     <EditableLabel onEdit={(newBatchName) => renameBatch(batch.id, newBatchName)}>
                       {batch.name}
                     </EditableLabel>
-                  </span>
+                  </div>
                 </Tooltip>
               </StyledBatchTitle>
 
@@ -213,7 +213,7 @@ const TransactionCounterDot = styled(Dot)`
   flex-shrink: 0;
 `;
 
-const StyledBatchTitle = styled(Text)`
+const StyledBatchTitle = styled.div`
   padding-left: 4px;
   min-width: 10px;
 `;


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/400

## How this PR fixes it
There is a bug in Firefox with contenteditable spans that makes copying the editable content copy the span itself as well

https://stackoverflow.com/questions/26057848/cut-paste-from-to-contenteditable-to-itself-does-not-work-in-firefox

We are changing the span to a div