### PR TITLE
fix: restore iconPath in manifest files

### DIFF
--- a/apps/compound/public/manifest.json
+++ b/apps/compound/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Compound",
   "description": "Money markets on the Ethereum blockchain",
+  "iconPath": "Compound.png",
   "icons": [
     {
       "src": "Compound.png",

--- a/apps/drain-safe/public/manifest.json
+++ b/apps/drain-safe/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Drain Account",
   "description": "Transfer all your assets in batch",
+  "iconPath": "logo.svg",
   "icons": [
     {
       "src": "logo.svg",

--- a/apps/ramp-network/public/manifest.json
+++ b/apps/ramp-network/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Ramp Network",
   "description": "Buy crypto directly from your Safe",
+  "iconPath": "ramp.svg",
   "icons": [
     {
       "src": "ramp.svg",

--- a/apps/tx-builder/public/manifest.json
+++ b/apps/tx-builder/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Transaction Builder",
   "description": "A Safe app to compose custom transactions",
+  "iconPath": "tx-builder.png",
   "icons": [
     {
       "src": "tx-builder.png",

--- a/apps/wallet-connect/public/manifest.json
+++ b/apps/wallet-connect/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "WalletConnect",
   "description": "Allows your Gnosis Safe Multisig to connect to dapps via WalletConnect.",
+  "iconPath": "wallet-connect.svg",
   "icons": [
     {
       "src": "wallet-connect.svg",


### PR DESCRIPTION
## What it solves
Resolves an issue retrieving safe app info from the gateway

https://github.com/gnosis/safe-client-gateway/blob/1c52acd5dae1615064bfd29b5d78559684344869/src/providers/info.rs#L152

## How this PR fixes it
Restoring iconPaths while not changed in the gateway

