### PR TITLE
fix: add least-privilege permissions to workflows

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'composite'
   steps:
     - name: Node.js setup
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'yarn'
@@ -40,7 +40,7 @@ runs:
       run: yarn install --frozen-lockfile
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,12 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+          ref: c4fd58f9c721aca09b841c8035ce1d115ed5f3c3 # v2.4.18
       - name: 'CLA Assistant'
         uses: ./reusable-workflows/actions/cla
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,41 +5,26 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-permissions:
-  actions: write
-  contents: read
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
-  CLAAssistant:
+  CLAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
-      - name: 'CLA Assistant'
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+      - name: Checkout reusable workflows
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          # user names of users allowed to contribute without CLA
+          repository: safe-global/github-reusable-workflows
+          token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
+          path: reusable-workflows
+          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+      - name: 'CLA Assistant'
+        uses: ./reusable-workflows/actions/cla
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
           allowlist: clovisdasilvaneto,rmeissner,Uxio0,dasanra,francovenica,luarx,yagopv,usame-algan,bot*
-
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-organization-name: 'safe-global'
-          # enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: 'cla-signatures'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -15,6 +15,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
 
       - name: Test, Build, Deploy PR
         run: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: 'PRaul: Comment PR with app URLs'
         if: success() && github.event.number
-        uses: mshick/add-pr-comment@v1
+        uses: mshick/add-pr-comment@a96c578acba98b60f16c6866d5f20478dc4ef68b # v1
         with:
           message: |
             * [Drain Account App](${{ env.REVIEW_FEATURE_URL }}/drain-safe/)
@@ -77,7 +77,7 @@ jobs:
     if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
 
       - name: Test and Build
         run: |
@@ -123,7 +123,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,6 +10,11 @@ on:
       - development
   # Run manually to version/production deployment/github releases
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   REPO_NAME_ALPHANUMERIC: safereactapps
   HUSKY: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: 'ESLint check'
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/safe-apps-check.yml
+++ b/.github/workflows/safe-apps-check.yml
@@ -35,9 +35,9 @@ jobs:
     # let's make sure our tests pass on Chrome browser
     name: E2E on Chrome
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Mainnet
         with:
           browser: chrome
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Gnosis Chain
         with:
           browser: chrome
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Polygon
         with:
           browser: chrome
@@ -91,7 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: BNB Smart Chain
         with:
           browser: chrome
@@ -109,7 +109,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Arbitrum
         with:
           browser: chrome
@@ -127,7 +127,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Aurora
         with:
           browser: chrome
@@ -145,7 +145,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Avalanche
         with:
           browser: chrome
@@ -163,7 +163,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         name: Optimism
         with:
           browser: chrome

--- a/.github/workflows/safe-apps-check.yml
+++ b/.github/workflows/safe-apps-check.yml
@@ -26,6 +26,9 @@ on:
   #   # At 4:00 on every day-of-week from Monday through Friday
   #   - cron: '0 4 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -16,12 +16,12 @@ jobs:
     name: Execute E2E tests
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d # 0.8.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout web-core
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: safe-global/web-core
           ref: main
@@ -32,7 +32,7 @@ jobs:
         run: yarn install
 
       - name: Yarn cache web-core modules
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: 'web-core/**/node_modules'
           key: web-core-modules-${{ hashFiles('**/yarn.lock') }}
@@ -69,13 +69,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || github.event.schedule == '0 9 * * 1-5' }}
 
       - name: Checkout safe-react-apps
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: safe-global/safe-react-apps
           path: apps
 
       - name: Execute E2E tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         with:
           browser: chrome
           record: true

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -6,6 +6,10 @@ on:
       - development
       - main
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the `actions/missing-workflow-permissions` warnings by adding least-privilege `permissions` blocks to all six workflows.

- `cla.yml`: `pull-requests`/`statuses: write` for the CLA bot to comment/set status, `actions: write` so it can re-trigger itself. Signatures are written to the remote repo via the bot's `PERSONAL_ACCESS_TOKEN`, not `GITHUB_TOKEN`.
- `conventional-commit-check.yml`: `pull-requests: read` is enough for `amannn/action-semantic-pull-request` to read the title.
- `deployment.yml`: `contents: read` for checkout, `pull-requests: write` for the PR-URL comment job.
- `lint.yml`, `safe-apps-check.yml`: `contents: read`.
- `safe-apps-e2e.yml`: `actions: write` for `styfle/cancel-workflow-action`, `contents: read` for checkout.
