### PR TITLE
feat: Migrate AWS credentials to OIDC and pin action SHAs

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,21 +7,12 @@ inputs:
     description: Node.js version
     required: false
     default: 18
-  aws-secret-access-key:
-    description: AWS secret access key
-    required: true
-  aws-access-key-id:
-    description: AWS access key id
-    required: true
-  aws-region:
-    description: AWS region
-    required: true
 
 runs:
   using: 'composite'
   steps:
     - name: Node.js setup
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'yarn'
@@ -39,9 +30,3 @@ runs:
       shell: bash
       run: yarn install --frozen-lockfile
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,6 +10,11 @@ on:
       - development
   # Run manually to version/production deployment/github releases
   workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
 env:
   REPO_NAME_ALPHANUMERIC: safereactapps
   HUSKY: 0
@@ -20,19 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-env
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Test, Build, Deploy PR
         run: |
@@ -52,7 +59,7 @@ jobs:
 
       - name: 'PRaul: Comment PR with app URLs'
         if: success() && github.event.number
-        uses: mshick/add-pr-comment@v1
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
         with:
           message: |
             * [Drain Account App](${{ env.REVIEW_FEATURE_URL }}/drain-safe/)
@@ -72,18 +79,20 @@ jobs:
     if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-env
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Test and Build
         run: |
@@ -118,15 +127,17 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: main
 
       - uses: ./.github/actions/setup-env
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: 'Deploy production'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,9 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/safe-apps-check.yml
+++ b/.github/workflows/safe-apps-check.yml
@@ -32,9 +32,9 @@ jobs:
     # let's make sure our tests pass on Chrome browser
     name: E2E on Chrome
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Mainnet
         with:
           browser: chrome
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Gnosis Chain
         with:
           browser: chrome
@@ -70,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Polygon
         with:
           browser: chrome
@@ -88,7 +88,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: BNB Smart Chain
         with:
           browser: chrome
@@ -106,7 +106,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Arbitrum
         with:
           browser: chrome
@@ -124,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Aurora
         with:
           browser: chrome
@@ -142,7 +142,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Avalanche
         with:
           browser: chrome
@@ -160,7 +160,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         name: Optimism
         with:
           browser: chrome

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -12,12 +12,12 @@ jobs:
     name: Execute E2E tests
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout web-core
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: safe-global/web-core
           ref: main
@@ -28,7 +28,7 @@ jobs:
         run: yarn install
 
       - name: Yarn cache web-core modules
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: 'web-core/**/node_modules'
           key: web-core-modules-${{ hashFiles('**/yarn.lock') }}
@@ -65,13 +65,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || github.event.schedule == '0 9 * * 1-5' }}
 
       - name: Checkout safe-react-apps
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: safe-global/safe-react-apps
           path: apps
 
       - name: Execute E2E tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@948d67d3074f1bbb6379c8bdbb04e95d2f8e593f # v7.4.0
         with:
           browser: chrome
           record: true


### PR DESCRIPTION
- Remove static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from all jobs
- Refactor setup-env composite action: remove AWS credential inputs and configure-aws-credentials step(credential config now lives in calling workflow)
- Add permissions: id-token: write at workflow level in deployment.yml
- Add configure-aws-credentials with role-to-assume: `AWS_ROLE_TO_ASSUME_STAGING` directly in pr, deploy, and release jobs
- Pin all action versions to full SHA hashes across all workflow files

Part of [INFSEC-1135](https://linear.app/safe-global/issue/INFSEC-1135/migrate-github-actions-secrets-to-oidc).

